### PR TITLE
Support TOTP login with 2FA-enabled accounts

### DIFF
--- a/autotests/rocketchatmessagetest.cpp
+++ b/autotests/rocketchatmessagetest.cpp
@@ -395,7 +395,7 @@ void RocketChatMessageTest::shouldLogin()
 {
     RocketChatMessage m;
     m.setJsonFormat(QJsonDocument::Indented);
-    RocketChatMessage::RocketChatMessageResult r = m.login(QStringLiteral("user"), QStringLiteral("password"), 43);
+    RocketChatMessage::RocketChatMessageResult r = m.login(QStringLiteral("user"), QStringLiteral("password"), QStringLiteral(), 43);
     compareFile(r.result, QStringLiteral("login"));
 }
 

--- a/src/apps/qml/Login.qml
+++ b/src/apps/qml/Login.qml
@@ -35,6 +35,7 @@ Kirigami.Page {
     property QtObject rcAccount
     property alias username: usernameField.text;
     property alias password: passField.text;
+    property alias code: codeField.text;
     property alias serverUrl: urlField.text;
     property alias accountName: nameField.text;
 
@@ -154,6 +155,25 @@ Kirigami.Page {
         PasswordLineEdit {
             id: passField
             width: parent.width
+            onAccepted: {
+                if (acceptingButton.enabled) {
+                    acceptingButton.clicked();
+                }
+            }
+        }
+
+        QQC2.Label {
+            id: codeLabel
+
+            width: parent.width
+            text: i18n("Enter a 2FA code or a recovery code")
+            visible: rcAccount.loginStatus === DDPClient.LoginFailed
+        }
+
+        PasswordLineEdit {
+            id: codeField
+            width: parent.width
+            visible: rcAccount.loginStatus === DDPClient.LoginFailed
             onAccepted: {
                 if (acceptingButton.enabled) {
                     acceptingButton.clicked();

--- a/src/apps/qml/LoginPage.qml
+++ b/src/apps/qml/LoginPage.qml
@@ -35,11 +35,13 @@ Login {
     username: rcAccount.userName
     originalAccountName: rcAccount.accountName
     password: rcAccount.password
+    code: rcAccount.code
     onAccepted: {
         //TODO ?
         //rcAccount.updateAccountSettings(loginTab.accountName, loginTab.password, loginTab.username, loginTab.serverUrl)
         rcAccount.accountName = loginTab.accountName;
         rcAccount.password = loginTab.password;
+        rcAccount.code = loginTab.code;
         rcAccount.userName = loginTab.username;
         rcAccount.serverUrl = loginTab.serverUrl;
         rcAccount.tryLogin();

--- a/src/ruqolacore/ddpapi/ddpclient.cpp
+++ b/src/ruqolacore/ddpapi/ddpclient.cpp
@@ -670,7 +670,7 @@ quint64 DDPClient::loginProvider(const QString &credentialToken, const QString &
 
 quint64 DDPClient::login(const QString &username, const QString &password)
 {
-    const RocketChatMessage::RocketChatMessageResult result = mRocketChatMessage->login(username, password, m_uid);
+    const RocketChatMessage::RocketChatMessageResult result = mRocketChatMessage->login(username, password, mRocketChatAccount->settings()->code(), m_uid);
     return method(result, login_result, DDPClient::Ephemeral);
 }
 
@@ -827,10 +827,17 @@ void DDPClient::onTextMessageReceived(const QString &message)
             Q_EMIT result(id, QJsonDocument(root.value(QLatin1String("result")).toObject()));
 
             if (id == m_loginJob) {
-                if (root.value(QLatin1String("error")).toObject().value(QLatin1String("error")).toInt() == 403) {
+                QJsonObject error(root.value(QLatin1String("error")).toObject());
+                QJsonValue errorValue(error.value(QLatin1String("error")));
+                if (errorValue.toInt() == 403) {
                     qCDebug(RUQOLA_DDPAPI_LOG) << "Wrong password or token expired";
 
                     login(); // Let's keep trying to log in
+                } else if (errorValue.toString() == QLatin1String("totp-required")) {
+                    qCDebug(RUQOLA_DDPAPI_LOG) << "A 2FA code is required to login";
+                    setLoginStatus(LoginFailed);
+                } else if (!error.isEmpty()) {
+                    qCDebug(RUQOLA_DDPAPI_LOG) << error.value(QLatin1String("message")).toString();
                 } else {
                     const QString token = root.value(QLatin1String("result")).toObject().value(QLatin1String("token")).toString();
                     mRocketChatAccount->settings()->setAuthToken(token);

--- a/src/ruqolacore/rocketchataccount.cpp
+++ b/src/ruqolacore/rocketchataccount.cpp
@@ -1213,6 +1213,11 @@ QString RocketChatAccount::password() const
     return settings()->password();
 }
 
+QString RocketChatAccount::code() const
+{
+    return settings()->code();
+}
+
 void RocketChatAccount::setAuthToken(const QString &token)
 {
     settings()->setAuthToken(token);
@@ -1221,6 +1226,11 @@ void RocketChatAccount::setAuthToken(const QString &token)
 void RocketChatAccount::setPassword(const QString &password)
 {
     settings()->setPassword(password);
+}
+
+void RocketChatAccount::setCode(const QString &code)
+{
+    settings()->setCode(code);
 }
 
 void RocketChatAccount::setUserName(const QString &username)

--- a/src/ruqolacore/rocketchataccount.h
+++ b/src/ruqolacore/rocketchataccount.h
@@ -79,6 +79,7 @@ class LIBRUQOLACORE_EXPORT RocketChatAccount : public QObject
     Q_PROPERTY(QString serverUrl READ serverUrl WRITE setServerUrl NOTIFY serverUrlChanged)
     Q_PROPERTY(QString accountName READ accountName WRITE setAccountName NOTIFY accountNameChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
+    Q_PROPERTY(QString code READ code WRITE setCode NOTIFY codeChanged)
     Q_PROPERTY(DDPClient::LoginStatus loginStatus READ loginStatus NOTIFY loginStatusChanged)
     Q_PROPERTY(bool editingMode READ editingMode NOTIFY editingModeChanged)
     Q_PROPERTY(bool sortUnreadOnTop READ sortUnreadOnTop NOTIFY sortUnreadOnTopChanged)
@@ -280,6 +281,9 @@ public:
     void setPassword(const QString &password);
     Q_REQUIRED_RESULT QString password() const;
 
+    void setCode(const QString &code);
+    Q_REQUIRED_RESULT QString code() const;
+
     void setAuthToken(const QString &token);
     Q_REQUIRED_RESULT QString authToken() const;
 
@@ -340,6 +344,7 @@ Q_SIGNALS:
     void userNameChanged();
     void userIDChanged();
     void passwordChanged();
+    void codeChanged();
     void serverUrlChanged();
     void loginStatusChanged();
     void logoutDone(const QString &accountname);

--- a/src/ruqolacore/rocketchataccountsettings.cpp
+++ b/src/ruqolacore/rocketchataccountsettings.cpp
@@ -161,6 +161,18 @@ void RocketChatAccountSettings::setPassword(const QString &password)
     Q_EMIT passwordChanged();
 }
 
+QString RocketChatAccountSettings::code() const
+{
+    return mCode;
+}
+
+void RocketChatAccountSettings::setCode(const QString &code)
+{
+    mCode = code;
+
+    Q_EMIT codeChanged();
+}
+
 QString RocketChatAccountSettings::userName() const
 {
     return mUserName;

--- a/src/ruqolacore/rocketchataccountsettings.h
+++ b/src/ruqolacore/rocketchataccountsettings.h
@@ -57,6 +57,9 @@ public:
     Q_REQUIRED_RESULT QString password() const;
     void setPassword(const QString &password);
 
+    Q_REQUIRED_RESULT QString code() const;
+    void setCode(const QString &code);
+
     void removeSettings();
 
     Q_REQUIRED_RESULT bool showUnreadOnTop() const;
@@ -68,6 +71,7 @@ Q_SIGNALS:
     void userIDChanged();
     void accountNameChanged();
     void passwordChanged();
+    void codeChanged();
 
 private:
     Q_DISABLE_COPY(RocketChatAccountSettings)
@@ -82,6 +86,7 @@ private:
     QString mCachePath;
     QString mUserName;
     QString mPassword;
+    QString mCode;
     QSettings *mSetting = nullptr;
     bool mShowUnreadOnTop = false;
 };

--- a/src/ruqolacore/rocketchatmessage.cpp
+++ b/src/ruqolacore/rocketchatmessage.cpp
@@ -467,7 +467,7 @@ RocketChatMessage::RocketChatMessageResult RocketChatMessage::roomFiles(const QS
     return subscribe(QStringLiteral("roomFiles"), QJsonDocument(params), id);
 }
 
-RocketChatMessage::RocketChatMessageResult RocketChatMessage::login(const QString &username, const QString &password, quint64 id)
+RocketChatMessage::RocketChatMessageResult RocketChatMessage::login(const QString &username, const QString &password, const QString &code, quint64 id)
 {
     QJsonObject user;
     user[QStringLiteral("username")] = username;
@@ -480,8 +480,18 @@ RocketChatMessage::RocketChatMessageResult RocketChatMessage::login(const QStrin
     passwordObject[QStringLiteral("algorithm")] = QStringLiteral("sha-256");
 
     QJsonObject params;
-    params[QStringLiteral("password")] = passwordObject;
-    params[QStringLiteral("user")] = user;
+    if (!code.isEmpty()) {
+        QJsonObject loginObject;
+        loginObject[QStringLiteral("user")] = user;
+        loginObject[QStringLiteral("password")] = passwordObject;
+        QJsonObject totpObject;
+        totpObject[QStringLiteral("code")] = code;
+        totpObject[QStringLiteral("login")] = loginObject;
+        params[QStringLiteral("totp")] = totpObject;
+    } else {
+        params[QStringLiteral("password")] = passwordObject;
+        params[QStringLiteral("user")] = user;
+    }
     return generateMethod(QStringLiteral("login"), QJsonDocument(params), id);
 }
 

--- a/src/ruqolacore/rocketchatmessage.h
+++ b/src/ruqolacore/rocketchatmessage.h
@@ -91,7 +91,7 @@ public:
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult roomFiles(const QString &roomId, quint64 id);
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult searchRoomUsers(const QString &pattern, const QString &exceptions, bool searchUser, bool searchRoom, quint64 id);
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult addUserToRoom(const QString &username, const QString &roomId, quint64 id);
-    Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult login(const QString &username, const QString &password, quint64 id);
+    Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult login(const QString &username, const QString &password, const QString& code, quint64 id);
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult inputChannelAutocomplete(const QString &pattern, const QString &exceptions, quint64 id);
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult inputUserAutocomplete(const QString &pattern, const QString &exceptions, quint64 id);
     Q_REQUIRED_RESULT RocketChatMessage::RocketChatMessageResult loginProvider(const QString &credentialToken, const QString &credentialSecretd, quint64 id);


### PR DESCRIPTION
The docs for the [Rocket.Chat realtime API](https://rocket.chat/docs/developer-guides/realtime-api/method-calls/login/) Ruqola is using unfortunately don't include handling of 2FA-enabled accounts. Login actually seems to succeed because only a `403` error code is handled when in fact `totp-required` is returned as a response. It's worth noting codes can apparently be both numeric and strings.
A peek at [the iOS client](https://github.com/RocketChat/Rocket.Chat.iOS/blob/ba49216daa50097745f15855238ef8f4d6519bcf/Rocket.Chat/Managers/Model/AuthManager/AuthManagerSocket.swift#L152) revealed how a login message needs to be constructed. Unlike the [login method of the REST API endpoint](https://rocket.chat/docs/developer-guides/rest-api/authentication/login/#example-call---when-two-factor2fa-authentication-is-enabled) the `code` isn't just added to the top-level.

On the UI side of things, an additional Code input needs to be shown in the login page.