### PR TITLE
Mark ManagerDataPaths as a proper export

### DIFF
--- a/src/ruqolacore/managerdatapaths.h
+++ b/src/ruqolacore/managerdatapaths.h
@@ -25,7 +25,7 @@
 #include <QString>
 #include "libruqola_private_export.h"
 
-class LIBRUQOLACORE_TESTS_EXPORT ManagerDataPaths
+class LIBRUQOLACORE_EXPORT ManagerDataPaths
 {
 public:
     enum PathType {


### PR DESCRIPTION
It is being used in main.cpp (ManagerDataPaths::self())